### PR TITLE
eventの日付ソート, 検索機能の追加, 一覧のjjson出力の修正

### DIFF
--- a/rails_app/app/controllers/events_controller.rb
+++ b/rails_app/app/controllers/events_controller.rb
@@ -9,10 +9,18 @@ class EventsController < ApplicationController
   # GET /events.json
   def index
     if params[:channel_id] == nil
-      events = Event.all
+      events = Event.all.order(:host_date)
     else
-      events = Event.where(channel_id: params[:channel_id])
+      events = Event.where(channel_id: params[:channel_id]).order(:host_date)
     end
+    render json: events
+  end
+
+  #イベントの検索をするAPI
+  # GET /events/search?word={}
+  def search
+    search_word = params[:word]
+    events = Event.all.where('name LIKE ?', "%#{search_word}%").order(:host_date)
     render json: events
   end
 

--- a/rails_app/app/controllers/events_controller.rb
+++ b/rails_app/app/controllers/events_controller.rb
@@ -8,11 +8,13 @@ class EventsController < ApplicationController
   # GET /events?channel_id={id}
   # GET /events.json
   def index
+    events = Hash.new
     if params[:channel_id] == nil
-      events = Event.all.order(:host_date)
+      res = Event.all.order(:host_date)
     else
-      events = Event.where(channel_id: params[:channel_id]).order(:host_date)
+      res = Event.where(channel_id: params[:channel_id]).order(:host_date)
     end
+    events["events"] = res.to_a
     render json: events
   end
 
@@ -20,7 +22,9 @@ class EventsController < ApplicationController
   # GET /events/search?word={}
   def search
     search_word = params[:word]
-    events = Event.all.where('name LIKE ?', "%#{search_word}%").order(:host_date)
+    events = Hash.new
+    res = Event.all.where('name LIKE ?', "%#{search_word}%").order(:host_date)
+    events["events"] = res.to_a
     render json: events
   end
 

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
-  resources :events
+  get 'events/search', to: 'events#search'
   post 'events/:id/participate/:user_id', to: 'events#participate'
-  
+  resources :events
   resources :comments
   resources :channels
   resources :users


### PR DESCRIPTION
# WHY
・イベントの一覧画面を日付でソートしたい
・イベントの検索をしたい
・イベント一覧のjson出力の形式を使用通りに変更したい
# WHAT
・イベントの一覧画面を昇順でソートするようにしました
・イベントの名前(name)であいまい検索できるようにしました
　`GET /events/search?word={}`
・イベント一覧のjson出力の形式を変更

before
 `{ {event_id, event_name, event_abstract, host_date, from,to,zoom_url}, ... }`
after
`{"events": [ { id, channel_id, name, abstract, zoom_url, host_date, from_date, to_date, ...} ]}`