### PR TITLE
【Fix】eventの検索(search)の修正

### DIFF
--- a/rails_app/app/controllers/events_controller.rb
+++ b/rails_app/app/controllers/events_controller.rb
@@ -5,25 +5,17 @@ require 'json'
 class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update, :destroy]
 
-  # GET /events?channel_id={id}
+  # GET /events?channel_id={id}&word={}
   # GET /events.json
   def index
     events = Hash.new
     if params[:channel_id] == nil
       res = Event.all.order(:host_date)
     else
-      res = Event.where(channel_id: params[:channel_id]).order(:host_date)
+      res = Event.where(channel_id: params[:channel_id])
     end
-    events["events"] = res.to_a
-    render json: events
-  end
-
-  #イベントの検索をするAPI
-  # GET /events/search?word={}
-  def search
     search_word = params[:word]
-    events = Hash.new
-    res = Event.all.where('name LIKE ?', "%#{search_word}%").order(:host_date)
+    res = res.where('name LIKE ?', "%#{search_word}%").order(:host_date)
     events["events"] = res.to_a
     render json: events
   end

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'events/search', to: 'events#search'
   post 'events/:id/participate/:user_id', to: 'events#participate'
   resources :events
   resources :comments


### PR DESCRIPTION
# Issue
eventのsearch関数にて、チャンネルのID(channel_id)と検索ワード(word)を同時に渡して検索できなかった

# What
イベント一覧用のAPI(events#index)にクエリパラメータとして検索ワードを渡せるように変更。またsearch関数は不要になったため削除